### PR TITLE
Remove io.netty and vertx dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,21 +61,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.vertx</groupId>
-			<artifactId>vertx-core</artifactId>
-			<version>3.2.1</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>1.9.5</version>
-		</dependency>
-
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-all</artifactId>
-			<version>4.1.8.Final</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Remove io.netty and vertx dependencies in pom.xml

Signed-off-by: Nelson Victor Cruz Hdez <victor.cruz.isc@gmail.com>