### PR TITLE
ALPHAL-366 New method to cancel all orders instead sending id by id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 
 group = 'com.bitso'
-version = '3.1.0-SNAPSHOT'
+version = '3.2.0-SNAPSHOT'
 
 description = """bitso-java"""
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>com.bitso</groupId>
 	<artifactId>bitso-java</artifactId>
 	<packaging>jar</packaging>
-	<version>3.0.4-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
 	<name>bitso-java</name>
 	<description>A Java wrapper for the Bitso Exchange API</description>
 	<url>https://bitso.com</url>

--- a/src/main/java/com/bitso/Bitso.java
+++ b/src/main/java/com/bitso/Bitso.java
@@ -444,6 +444,15 @@ public class Bitso {
         return Helpers.getJSONArrayElements(payloadJSON);
     }
 
+    public String[] cancelAllOrders()
+            throws BitsoAPIException, BitsoPayloadException, BitsoServerException {
+        String request = "/api/v3/orders/all";
+        log(request);
+        String deleteResponse = sendBitsoDelete(request);
+        JSONArray payloadJSON = (JSONArray) getJSONPayload(deleteResponse);
+        return Helpers.getJSONArrayElements(payloadJSON);
+    }
+
     public Map<String, String> fundingDestination(String currencyParameter)
             throws BitsoAPIException, BitsoPayloadException, BitsoServerException {
         String request = "/api/v3/funding_destination";


### PR DESCRIPTION
### Associated task:
https://bitsomx.atlassian.net/browse/ALPHAL-366

## Changes
This PR contains a new method to call the endpoint for canceling orders, but using the path `/all`

### Testing
![image](https://user-images.githubusercontent.com/37350709/101396730-63295a80-3891-11eb-950f-4a1d9ccbed80.png)
