### PR TITLE
HF: Security reported issue with netty-all 4.1.42.Final version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version:'4.3.6'
     compile group: 'org.json', name: 'json', version:'20140107'
     compile group: 'org.mockito', name: 'mockito-all', version:'1.9.5'
-    compile group: 'io.netty', name: 'netty-all', version:'4.1.42.Final'
+    compile group: 'io.netty', name: 'netty-all', version:'4.1.55.Final'
     testCompile group: 'junit', name: 'junit', version:'4.12'
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.1.42.Final</version>
+            <version>4.1.55.Final</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
## Changes: 
* netty-all.4.1.42.Final has a reported security issue

![Screenshot 2020-12-14 at 19 36 05](https://user-images.githubusercontent.com/675357/102158012-22f44a00-3e46-11eb-9ddf-877bb4e65748.png)
